### PR TITLE
fix: remove usage of `blob:none` filter until new git releases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: "Sparse checkout action"
-description: "Sparse checkout a git repository"
+name: 'Sparse checkout action'
+description: 'Sparse checkout a git repository'
 branding:
-  icon: "minimize-2"
-  color: "gray-dark"
+  icon: 'minimize-2'
+  color: 'gray-dark'
 inputs:
   # Sparse checkout
   patterns:
@@ -14,7 +14,7 @@ inputs:
 
   # Same as actions/checkout
   repository:
-    description: "Repository name with owner. For example, snow-actions/sparse-checkout"
+    description: 'Repository name with owner. For example, snow-actions/sparse-checkout'
     default: ${{ github.repository }}
     required: false
 
@@ -23,7 +23,7 @@ inputs:
       The branch, tag or SHA to checkout. When checking out the repository that
       triggered a workflow, this defaults to the reference or SHA for that
       event.  Otherwise, uses the default branch.
-    default: ""
+    default: ''
     required: false
 
   token:
@@ -40,8 +40,8 @@ inputs:
     required: false
 
   path:
-    description: "Relative path under $GITHUB_WORKSPACE to place the repository"
-    default: "."
+    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+    default: '.'
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,7 @@ runs:
     - name: Cloning the repository
       run: |
         echo "::group::Cloning the repository"
+        # change back --filter=blob:limit=1 to --filter=blob:none after git/git#1535 is merged
         git clone --filter=blob:limit=1 --no-checkout "${GITHUB_SERVER_URL}/${REPOSITORY}" .
         echo "::endgroup::"
         echo "::group::Disabling automatic garbage collection"

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: 'Sparse checkout action'
-description: 'Sparse checkout a git repository'
+name: "Sparse checkout action"
+description: "Sparse checkout a git repository"
 branding:
-  icon: 'minimize-2'
-  color: 'gray-dark'
+  icon: "minimize-2"
+  color: "gray-dark"
 inputs:
   # Sparse checkout
   patterns:
@@ -14,7 +14,7 @@ inputs:
 
   # Same as actions/checkout
   repository:
-    description: 'Repository name with owner. For example, snow-actions/sparse-checkout'
+    description: "Repository name with owner. For example, snow-actions/sparse-checkout"
     default: ${{ github.repository }}
     required: false
 
@@ -23,7 +23,7 @@ inputs:
       The branch, tag or SHA to checkout. When checking out the repository that
       triggered a workflow, this defaults to the reference or SHA for that
       event.  Otherwise, uses the default branch.
-    default: ''
+    default: ""
     required: false
 
   token:
@@ -40,8 +40,8 @@ inputs:
     required: false
 
   path:
-    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
-    default: '.'
+    description: "Relative path under $GITHUB_WORKSPACE to place the repository"
+    default: "."
     required: false
 
 runs:
@@ -69,7 +69,7 @@ runs:
     - name: Cloning the repository
       run: |
         echo "::group::Cloning the repository"
-        git clone --filter=blob:none --no-checkout "${GITHUB_SERVER_URL}/${REPOSITORY}" .
+        git clone --filter=blob:limit=1 --no-checkout "${GITHUB_SERVER_URL}/${REPOSITORY}" .
         echo "::endgroup::"
         echo "::group::Disabling automatic garbage collection"
         git config --local gc.auto 0


### PR DESCRIPTION
We discovered that `git fetch` fails with these strange lines when repository is cloned with `--filter=blob:none`:    
```bash
BUG: config.c:129: kvi should not be set while parsing a config source
Aborted (core dumped)
```
It seems like the only workaround is to filter all files which has size of one or more bytes, instead of just preventing all files from being cloned. I know it is really silly, but this is the only to way to cope with the regression of Git itself.